### PR TITLE
Fix mismatches between docs and code

### DIFF
--- a/src/twitter-mentionv2.coffee
+++ b/src/twitter-mentionv2.coffee
@@ -8,7 +8,7 @@
 # Configuration:
 #   HUBOT_TWITTER_CONSUMER_KEY
 #   HUBOT_TWITTER_CONSUMER_SECRET
-#   HUBOT_TWITTER_ACCESS_TOKEN
+#   HUBOT_TWITTER_ACCESS_TOKEN_KEY
 #   HUBOT_TWITTER_ACCESS_TOKEN_SECRET
 #   HUBOT_TWITTER_MENTION_QUERY
 #   HUBOT_TWITTER_MENTION_ROOM
@@ -40,7 +40,7 @@ module.exports = (robot) ->
     doAutomaticSearch(robot)
 
   doAutomaticSearch = (robot) ->
-    query = process.env.HUBOT_TWITTER_QUERY
+    query = process.env.HUBOT_TWITTER_MENTION_QUERY
     since_id = robot.brain.data.last_tweet
     count = MAX_TWEETS
 


### PR DESCRIPTION
I went with `HUBOT_TWITTER_ACCESS_TOKEN_KEY` because that seemed to be the way other scripts were leaning in https://github.com/github/hubot-scripts:

| HUBOT_TWITTER_ACCESS_TOKEN_KEY | [2 scripts](https://github.com/github/hubot-scripts/search?utf8=%E2%9C%93&q=HUBOT_TWITTER_ACCESS_TOKEN_KEY&type=Code) |
| --- | --- |
| HUBOT_TWITTER_ACCESS_TOKEN | [1 script](https://github.com/github/hubot-scripts/search?utf8=%E2%9C%93&q=HUBOT_TWITTER_ACCESS_TOKEN&type=Code) |

And with `HUBOT_TWITTER_MENTION_QUERY` since it makes more sense in the context of this plugin.
